### PR TITLE
Added Settings and other Configuration Options

### DIFF
--- a/common.py
+++ b/common.py
@@ -6,8 +6,8 @@ from oauth.oauth import OAuthToken
 import os
 
 # Get your own app key and secret from the Dropbox developer website
-APP_KEY = 'f2uu8y1z8a2pr8a'
-APP_SECRET = 'qmyxhrekjtxsjtd'
+APP_KEY = 'XXXXXXXXXX'
+APP_SECRET = 'XXXXXXXX'
 
 # ACCESS_TYPE should be 'dropbox' or 'app_folder' as configured for your app
 ACCESS_TYPE = 'dropbox'

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,110 @@
+import sys
+import re
+import datetime
+
+def processSettings(args):
+	# First make sure that the user provided the minimum number of arguments (2):
+	if len(args) < 2:
+		print "Usage: recover.py [-dDRm] [flag arguments] <output folder> <start walk>"
+		sys.exit(1)
+	
+
+	''' Each flag will trigger a specific function, specified in the 'all_settings' dict below.
+	When adding a new setting, you must give it a 'func' and define a function for it here. '''
+
+	def getMaxArguments(settings):
+		max_arg = 0
+		for key in settings:
+			if 'arguments' in settings[key]:
+				current_arg = settings[key]['arguments']
+				if current_arg > max_arg:
+					max_arg = current_arg
+		return max_arg			
+
+	def setMaxDays(key, str, settings):
+		# Cast the argument to an int
+		settings[key]['value'] = int(str)
+
+	def switchRestore(key, settings):
+		# Since restore is set to True by default, simply switch to False
+		settings[key]['value'] = False
+
+	def compileDate(value):
+		# Convert the date string of format MM/DD/YYYY or MM/DD/YY to datetime
+		# A helper function for all of the date options
+		date_re = re.compile(r'(\d+)/(\d+)/(\d+)')
+
+		search_month = int(date_re.search(value).groups()[0]) or None
+		search_day = int(date_re.search(value).groups()[1]) or None
+		search_year = int(date_re.search(value).groups()[2]) or None
+
+
+		if search_month and search_day and search_year:
+			return datetime.datetime(month=search_month, day=search_day, year=search_year)
+		else:
+			print "Date(s) must be in the format MM/DD/YY or MM/DD/YYYY"
+			sys.exit(1)
+
+	def getSingleDate(key, value, settings):
+		# Sets the 'value' of 'search_date' to a single datetime object
+		print "Looking for files deleted on %s" % value
+		date = compileDate(value)
+		settings[key]['value'] = date
+
+	def getDateRange(key, values_array, settings):
+		# Sets the 'value' of 'search_date_range' to a tuple of beginning and end datetimes
+		print "Looking for files deleted between %s and %s" % (values_array[0], values_array[1])
+		beginning = compileDate(values_array[0])
+		end = compileDate(values_array[1])
+		settings[key]['value'] = (beginning, end)		 
+
+
+	# All of the possible settings (before processing)
+	# If you want to add any available settings, this is where you'd do it.
+	# If a given flag doesn't take any arguments, like -R, you must specify with 'arguments'.
+	# Same goes if a given flag takes more than 1 argument
+	all_settings = {
+		# Sets the max days back a restoration should go (defaults to None)
+		'max_days': { 'value': None, 'flag': '-m', 'arguments': 1, 'func': setMaxDays },
+
+		# Switches whether or not to use Dropbox restore mode instead of copying files (default is True)
+		'use_restore': { 'value': True, 'flag': '-R', 'arguments': 0, 'func': switchRestore },
+
+		# Set a specific date on which files were deleted in order to restore them (default None)
+		'search_date': { 'value': None, 'flag': '-d', 'arguments': 1, 'func': getSingleDate },
+
+		# Set a range of dates in which files could have been deleted (default None)
+		'search_date_range': { 'value': None, 'flag': '-D', 'arguments': 2, 'func': getDateRange },
+	}
+
+	''' Here is where the main processing of the arguments takes place.
+	It will return a dictionary of settings and their values without any other information. '''
+	max_args = getMaxArguments(all_settings)
+	args_len = len(args)
+
+	# Loop over system arguments
+	''' This is kind of a mess for now. There is no error checking,
+	so subsequent flags could be passed in as args '''
+	for i in range(0, args_len - max_args):
+		for key in all_settings:
+			current_setting = all_settings[key]
+			if current_setting['flag'] == args[i]:
+				if current_setting['arguments'] > 1:
+					values = []
+					for x in range(0, current_setting['arguments']):
+						values.append(args[i+x+1])
+					current_setting['func'](key, values, all_settings)	
+				elif current_setting['arguments'] == 1:
+					current_setting['func'](key, args[i+1], all_settings)
+				else:
+					current_setting['func'](key, all_settings)
+
+	# Return a dictionary with all settings values that have been set
+	config = {}
+
+	for key in all_settings:
+		config[key] = all_settings[key]['value']
+	config['start_walk'] = args[-1]
+	config['recover_to'] = args[-2]	
+
+	return config	


### PR DESCRIPTION
I came across your program today when I had to help someone in real estate recover over 5k files that had been mysteriously deleted from Dropbox. In our case, all the files were deleted on a specific date, so at the time I changed one line in your program, ran it, and everything worked A-Ok. That said, I decided I should add that capability, which then turned into a bunch of other things.

Here's the basic idea: I've added a `settings.py` file and I have the `undelete.py` import it. Basically, it takes the system arguments and parses them based on a `dict` of possible settings (which anyone can customize) and returns a different `dict` with all of the configured settings. You'll see in the `undelete` file that this ends up being something called `config`. 

The `all_settings' dictionary in`settings.py`might look a little confusing, but it really isn't. Every new "feature" added here will have to have a`func`key that points to a function to be executed if the user provides the given flag (so when adding a new feature, be sure to write the function too). The`arguments` key is needed because some settings might take multiple arguments and others might take none at all. for example:

`shell$: python undelete.py -R ./ /`

This simply switches `use_recovery` (formerly a constant called `USE_RECOVERY`) to `False` because the default value is always `True`. As such, it takes no arguments.

On the other hand:

`shell$: python undelete.py -D 10/27/2013 11/1/2013 ./ /`

The `-D` flag takes two arguments, a beginning date and end date in `MM/DD/YY` or `MM/DD/YYYY` format. When you look in the `undelete` file you'll see that if this is enabled, the program will only look for files deleted within that range. On a related note, the `-d` flag only looks for files deleted on a given date, which it what I used to get out of the mess that brought me here in the first place.

That about covers what I've done so far. The only problems I see are that the `settings.py` processing doesn't error-check to see whether the correct number of arguments follow a given flag. That's definitely an issue.

Here is an example with multiple flags:

`shell$: python undelete.py -D 5/23/2013 6/4/2013 -d 7/23/2013 -R ./ /`

This command will search for files deleted within the date range AND on a specific date. It will also disable Recovery mode.
